### PR TITLE
添加 CORS 中间件支持和配置选项

### DIFF
--- a/meme_generator/app.py
+++ b/meme_generator/app.py
@@ -4,6 +4,7 @@ from typing import Any, Literal, Optional
 
 import filetype
 from fastapi import Depends, FastAPI, Form, HTTPException, Response, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, ValidationError
 
 from meme_generator.compat import model_dump, model_json_schema, type_validate_python
@@ -19,6 +20,17 @@ from meme_generator.meme import CommandShortcut, Meme, MemeArgsModel, ParserOpti
 from meme_generator.utils import MemeProperties, render_meme_list, run_sync
 
 app = FastAPI()
+
+
+if meme_config.server.CORS_switch:
+    config = meme_config.server.CORS_config
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=config.allow_origins,
+        allow_credentials=config.allow_credentials,
+        allow_methods=config.allow_methods, 
+        allow_headers=config.allow_headers,  
+    )
 
 
 class MemeArgsResponse(BaseModel):

--- a/meme_generator/config.py
+++ b/meme_generator/config.py
@@ -37,9 +37,18 @@ class TranslatorConfig(BaseModel):
     baidu_trans_apikey: str = ""
 
 
+class CORSConfig(BaseModel):
+    allow_origins: list[str] = ['*']
+    allow_credentials: bool = True
+    allow_methods: list[str] = ['*']
+    allow_headers: list[str] = ['*']
+
+
 class ServerConfig(BaseModel):
     host: str = "127.0.0.1"
     port: int = 2233
+    CORS_switch: bool = False
+    CORS_config: CORSConfig = CORSConfig()
 
 
 class LogConfig(BaseModel):


### PR DESCRIPTION
默认CORS支持为关,需要在配置文件添加
```toml
[server]
CORS_switch = true
```
还可以自定义CORS配置
```toml
[server]
CORS_switch = true
CORS_config = { allow_origins = ["*"], allow_credentials = true, allow_methods = ["*"], allow_headers = ["*"] }
```